### PR TITLE
Write2file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,15 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.10</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
         </dependency>
 
         <!--MQTT-->
@@ -123,6 +130,15 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.15.0</version>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
     <build>

--- a/src/main/java/pi/tracker/dto/PiSensorHubMetric.java
+++ b/src/main/java/pi/tracker/dto/PiSensorHubMetric.java
@@ -1,5 +1,6 @@
 package pi.tracker.dto;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.ToString;
 
@@ -7,6 +8,7 @@ import java.io.Serializable;
 
 @Data
 @ToString
+@Builder
 public class PiSensorHubMetric implements Serializable {
 
     private String timeStamp;

--- a/src/main/java/pi/tracker/mqtt/PahoPiTrackerMqttClient.java
+++ b/src/main/java/pi/tracker/mqtt/PahoPiTrackerMqttClient.java
@@ -1,5 +1,7 @@
 package pi.tracker.mqtt;
 
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.paho.client.mqttv3.MqttClient;
@@ -12,6 +14,10 @@ import javax.inject.Singleton;
 
 @Slf4j
 @Singleton
+// this allows to create this bean during Micronaut context creation, what makes this bean to intialize earlier
+// than the others
+@Context //FIXME: TBD-0 not sure if this needed if no logic to automatically fallback to local metrics saving is implemented
+@Requires(property = "pi-tracker.mqtt.enable", value = "true")
 public class PahoPiTrackerMqttClient implements PiTrackerMqttClient {
 
     //these injections work only after constructor has been executed

--- a/src/main/java/pi/tracker/service/impl/MqttDeliveryService.java
+++ b/src/main/java/pi/tracker/service/impl/MqttDeliveryService.java
@@ -1,21 +1,27 @@
 package pi.tracker.service.impl;
 
+import io.micronaut.context.annotation.Requires;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.SerializationUtils;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import pi.tracker.config.MqttDeliveryProperties;
 import pi.tracker.dto.PiSensorHubMetric;
+import pi.tracker.mqtt.PahoPiTrackerMqttClient;
 import pi.tracker.mqtt.PiTrackerMqttClient;
 import pi.tracker.service.MetricDeliverer;
 import pi.tracker.service.exceptions.DeliveryException;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+
 import javax.inject.Singleton;
 import java.util.Map;
 
 @Slf4j
 @Singleton
+@Named("mqtt")
+@Requires(beans = PahoPiTrackerMqttClient.class)
 public class MqttDeliveryService implements MetricDeliverer {
 
     private PiTrackerMqttClient client;

--- a/src/main/java/pi/tracker/service/impl/MqttDeliveryService.java
+++ b/src/main/java/pi/tracker/service/impl/MqttDeliveryService.java
@@ -18,14 +18,18 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Map;
 
+/**
+ * This bean is only initialized in case there is an instance of {@link PahoPiTrackerMqttClient};
+ * otherwise sensor data would be written into local file, see {@link ToFileDeliveryService}
+ */
 @Slf4j
 @Singleton
 @Named("mqtt")
 @Requires(beans = PahoPiTrackerMqttClient.class)
 public class MqttDeliveryService implements MetricDeliverer {
 
-    private PiTrackerMqttClient client;
-    private MqttDeliveryProperties deliveryProperties;
+    private final PiTrackerMqttClient client;
+    private final MqttDeliveryProperties deliveryProperties;
 
     @Inject
     public MqttDeliveryService(PiTrackerMqttClient mqttClient, MqttDeliveryProperties mqttDeliveryProperties) {

--- a/src/main/java/pi/tracker/service/impl/SensorHubServiceImpl.java
+++ b/src/main/java/pi/tracker/service/impl/SensorHubServiceImpl.java
@@ -60,7 +60,7 @@ public class SensorHubServiceImpl implements SensorHubService {
     private void serveAsMetric() {
         log.debug("Starting to collect data for metric from sensors...");
 
-        PiSensorHubMetric metric = new PiSensorHubMetric();
+        PiSensorHubMetric metric = PiSensorHubMetric.builder().build();
         metric.setTimeStamp(Timestamp.from(ZonedDateTime.now().toInstant()).toString());
         for (Sensor sensor : availableSensors) {
             String currentSensorName = sensor.getSensorName();
@@ -131,6 +131,7 @@ public class SensorHubServiceImpl implements SensorHubService {
     }
 
     private void publishMetric(PiSensorHubMetric metric) throws DeliveryException {
+        // todo add check on where to publish
         log.debug("Publishing metric {}", metric);
         deliverer.deliver(metric);
     }

--- a/src/main/java/pi/tracker/service/impl/ToFileDeliveryService.java
+++ b/src/main/java/pi/tracker/service/impl/ToFileDeliveryService.java
@@ -1,0 +1,60 @@
+package pi.tracker.service.impl;
+
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
+import pi.tracker.dto.PiSensorHubMetric;
+import pi.tracker.service.MetricDeliverer;
+import pi.tracker.service.exceptions.DeliveryException;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.*;
+import java.nio.file.*;
+import java.util.Map;
+
+@Slf4j
+@Singleton
+@Named("file")
+public class ToFileDeliveryService implements MetricDeliverer {
+
+    public static final String FILE_NAME = "pi-metrics";
+    public static final String FILE_PATH = System.getProperty("user.dir");
+    public static final String FILE_FULL_PATH = FILE_PATH + "/" + FILE_NAME;
+
+    @Override
+    public void deliver(Map.Entry<String, Integer> sensorData) throws DeliveryException {
+        // todo iterate over the map & write to file
+    }
+
+    @Override
+    public void deliver(PiSensorHubMetric metric) throws DeliveryException {
+        toSaveToFile(serializeToJson(metric));
+    }
+
+    private String serializeToJson(PiSensorHubMetric metric) {
+        return new Gson().toJson(metric);
+    }
+
+    private void toSaveToFile(String metricJson) {
+        Path path2File = Path.of(FILE_FULL_PATH);
+        if (Files.exists(path2File)) {
+            log.debug("Found file with metrics, appending data: {}", FILE_FULL_PATH);
+            try {
+                String metricForFile = metricJson + '\n';
+                Files.write(path2File, metricForFile.getBytes(), StandardOpenOption.APPEND);
+            } catch (IOException e) {
+                log.error("Failed to write to file", e );
+            }
+        } else {
+            log.debug("Creating file with metrics: {}", FILE_FULL_PATH);
+            try {
+//                Path filePath = Files.createFile(path2File);
+                Writer writer = Files.newBufferedWriter(path2File);
+                writer.append(metricJson).append('\n');
+                writer.close();
+            } catch (IOException e) {
+                log.error("Failed to create file", e);
+            }
+        }
+    }
+}

--- a/src/main/java/pi/tracker/service/impl/ToFileDeliveryService.java
+++ b/src/main/java/pi/tracker/service/impl/ToFileDeliveryService.java
@@ -12,6 +12,9 @@ import java.io.*;
 import java.nio.file.*;
 import java.util.Map;
 
+/**
+ * Used for storing of sensor data locally in the file.
+ */
 @Slf4j
 @Singleton
 @Named("file")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,10 @@ micronaut:
 pi-tracker:
   scheduled-mode:
     enabled: ${SCHEDULED_MODE:true}
-    cron: ${SCHEDULED_CRON:* * * * *}
+    cron: ${SCHEDULED_CRON:0 * * * *}
   use-raw-output: ${USE_RAW_OUTPUT:false}
   mqtt:
+    enable: ${MQTT_ENABLED:true}
     host: tcp://${MQTT_HOST:127.0.0.1}
     port: ${MQTT_PORT:1883}
     client-id: ${MQTT_CLIENT_ID:piTracker}

--- a/src/test/java/pi/tracker/service/impl/ToFileDeliveryServiceTest.java
+++ b/src/test/java/pi/tracker/service/impl/ToFileDeliveryServiceTest.java
@@ -1,0 +1,129 @@
+package pi.tracker.service.impl;
+
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import pi.tracker.dto.PiSensorHubMetric;
+import pi.tracker.service.exceptions.DeliveryException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static pi.tracker.service.impl.ToFileDeliveryService.FILE_FULL_PATH;
+
+public class ToFileDeliveryServiceTest {
+
+    @Before
+    public void setUp() throws IOException {
+        cleanTestDir();
+    }
+
+    private void cleanTestDir() throws IOException {
+        if (Files.deleteIfExists(Paths.get(FILE_FULL_PATH))) {
+            System.out.println("Found files from previous test runs, deleted them");
+        }
+    }
+
+    @Test
+    public void testWritingToFile() throws DeliveryException, IOException {
+        // GIVEN metric from board has arrived
+        PiSensorHubMetric testMetric = PiSensorHubMetric.builder()
+                .airPressureSensor(2.0)
+                .airPressureTemperature(12.0)
+                .human(1)
+                .light(42.0)
+                .onBoardHumidity(23.0)
+                .onBoardTemperature(32.0)
+                .externalTemperatureSensor(12.0)
+                .build();
+
+        // WHEN calling service to write to file
+        ToFileDeliveryService toFileDeliveryService = new ToFileDeliveryService();
+        toFileDeliveryService.deliver(testMetric);
+        // THEN expecting file to exist
+        boolean fileExists = Files.exists(Path.of(FILE_FULL_PATH));
+        assertThat(fileExists).isTrue();
+        List<PiSensorHubMetric> metricsFromFile = readFromMetricsFile();
+        // AND expecting file to contain exactly one line
+        assertThat(metricsFromFile.size()).isEqualTo(1);
+        // AND expecting metric to be the same
+        assertThat(metricsFromFile.get(0)).isEqualTo(testMetric);
+    }
+
+    @Test
+    public void testWritingMultipleMetricsToFile() throws DeliveryException, IOException {
+        // GIVEN metrics from board has arrived
+        PiSensorHubMetric testMetric = PiSensorHubMetric.builder()
+                .airPressureSensor(2.0)
+                .airPressureTemperature(12.0)
+                .human(1)
+                .light(42.0)
+                .onBoardHumidity(23.0)
+                .onBoardTemperature(32.0)
+                .externalTemperatureSensor(12.0)
+                .build();
+
+        PiSensorHubMetric metric1 = PiSensorHubMetric.builder()
+                .airPressureSensor(2.0)
+                .airPressureTemperature(12.0)
+                .human(1)
+                .light(42.0)
+                .onBoardHumidity(23.0)
+                .onBoardTemperature(32.0)
+                .externalTemperatureSensor(12.0)
+                .build();
+
+        PiSensorHubMetric metric2 = PiSensorHubMetric.builder()
+                .airPressureSensor(2.0)
+                .airPressureTemperature(12.0)
+                .human(1)
+                .light(42.0)
+                .onBoardHumidity(22.0)
+                .onBoardTemperature(22.0)
+                .externalTemperatureSensor(22.0)
+                .build();
+
+        List<PiSensorHubMetric> testMetrics = Arrays.asList(testMetric, metric1, metric2);
+
+        // WHEN calling service each to write to file
+        ToFileDeliveryService toFileDeliveryService = new ToFileDeliveryService();
+        testMetrics.forEach(metric -> {
+            try {
+                toFileDeliveryService.deliver(metric);
+            } catch (DeliveryException e) {
+                fail("Failed to call write to file");
+            }
+        });
+        // THEN expecting file to exist
+        boolean fileExists = Files.exists(Path.of(FILE_FULL_PATH));
+        assertThat(fileExists).isTrue();
+        List<PiSensorHubMetric> metricsFromFile = readFromMetricsFile();
+        // AND expecting file to contain orginal number of metrics
+        assertThat(metricsFromFile.size()).isEqualTo(testMetrics.size());
+        // AND expecting metric to be the same
+        metricsFromFile.forEach(metricFromFile -> {
+            assertThat(testMetrics).contains(metricFromFile);
+        });
+    }
+
+    private List<PiSensorHubMetric> readFromMetricsFile() throws IOException {
+        List<PiSensorHubMetric> metricsFromFile = new ArrayList<>();
+        // reading file
+        try (Stream<String> linesStream = Files.lines(Paths.get(FILE_FULL_PATH))) {
+            linesStream.forEach(line -> {
+                metricsFromFile.add(new Gson().fromJson(line, PiSensorHubMetric.class));
+            });
+        }
+        return metricsFromFile;
+    }
+
+}


### PR DESCRIPTION
Adde logic which allows to write metrics to file in the local file system.
It is activated if no mqtt client bean exists in the context, this is configured by property: `pi-tracker.mqtt.enable`